### PR TITLE
Dea tools version update

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,7 @@ affine>=2.3.0
 botocore
 click>=8.0.1
 datacube[s3,performance]>=1.8.6
-dea_tools>=0.2.8.dev11
+dea_tools>=0.2.8.dev13
 Fiona>=1.8.20
 geopandas>=0.10.2
 matplotlib>=3.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -112,7 +112,7 @@ datacube[performance,s3]==1.8.6
     #   dea-tools
     #   odc-algo
     #   odc-ui
-dea-tools==0.2.8.dev11
+dea-tools==0.2.8.dev13
     # via -r requirements.in
 debugpy==1.5.1
     # via ipykernel


### PR DESCRIPTION
Update version of dea_tools to include changes to allow building of docker image. 
dea_tools changes: import of otps and and pyfes have been to the function level so that dea_tools can still be used if you don't have access to those packages