### PR TITLE
Update insufficient observations flag to use relative vs absolute threshold

### DIFF
--- a/coastlines/vector.py
+++ b/coastlines/vector.py
@@ -1514,7 +1514,7 @@ def generate_vectors(
         #   likely to reflect modelling issues than real-world coastal change
         # - High angular variability: the nearest shorelines for each year do not
         #   fall on an approximate line, making rates of change invalid
-        # - Insufficient observations: less than 7% valid annual shorelines, which
+        # - Insufficient observations: less than 75% valid annual shorelines, which
         #   make the resulting rates of change more likely to be inaccurate
         rocky = [
             "Bedrock breakdown debris (cobbles/boulders)",

--- a/notebooks/DEACoastlines_generation_vector.ipynb
+++ b/notebooks/DEACoastlines_generation_vector.ipynb
@@ -366,7 +366,7 @@
     "- Likely rocky shorelines: Rates of change can be unreliable in areas with steep rocky/bedrock shorelines due to terrain shadow.\n",
     "- Extreme rate of change value (> 50 m per year change) that is more likely to reflect modelling issues than real-world coastal change\n",
     "- High angular variability: the nearest shorelines for each year do not fall on an approximate line, making rates of change invalid\n",
-    "- Insufficient observations: less than 25 valid annual shorelines, which make the resulting rates of change more likely to be inaccurate"
+    "- Insufficient observations: less than 75% valid annual shorelines, which make the resulting rates of change more likely to be inaccurate"
    ]
   },
   {
@@ -408,15 +408,16 @@
     "] = \"likely rocky coastline\"\n",
     "\n",
     "# Flag extreme rates of change\n",
-    "points_gdf.loc[\n",
-    "    points_gdf.rate_time.abs() > 50, \"certainty\"\n",
-    "] = \"extreme value (> 50 m)\"\n",
+    "points_gdf.loc[points_gdf.rate_time.abs() > 50, \"certainty\"] = \"extreme value (> 50 m)\"\n",
     "\n",
     "# Flag points where change does not fall on a line\n",
     "points_gdf.loc[points_gdf.angle_std > 30, \"certainty\"] = \"high angular variability\"\n",
     "\n",
     "# Flag shorelines with less than X valid shorelines\n",
-    "points_gdf.loc[points_gdf.valid_obs < 25, \"certainty\"] = \"insufficient observations\""
+    "valid_obs_thresh = int(points_gdf.columns.str.contains(\"dist_\").sum() * 0.75)\n",
+    "points_gdf.loc[\n",
+    "    points_gdf.valid_obs < valid_obs_thresh, \"certainty\"\n",
+    "] = \"insufficient observations\""
    ]
   },
   {

--- a/tests/test_coastline.py
+++ b/tests/test_coastline.py
@@ -64,7 +64,7 @@ def test_generate_continental_cli():
             "--ratesofchange",
             "True",
             "--hotspots",
-            "False",
+            "True",
             "--baseline_year",
             "2020",
         ]


### PR DESCRIPTION
Previously, rates of change were marked as having "insufficient observations" if there were less than 25 valid shoreline observations. This causes the hotspots generation code to fail however, as for shorter temporal epochs (e.g. 5 years) all points are marked as having insufficient observations, resulting in no valid data to generate the hotspots.

This PR changes the absolute 25 threshold to a relative threshold of 75% of all shorelines being valid. This converts to the same threshold for 34 years of data (34 * 0.75 = ~25), but should also work for much smaller periods too.

Have also updated the tests to restore hotspot generation after this change.