### PR TITLE
Add Github action to build and push docker image to Docker hub

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,51 @@
+name: Push
+
+on:
+  push:
+    branches:
+      - github_action_test
+    paths:
+      - 'coastlines/**'
+      - '.github/workflows/docker.yml'
+      - 'Dockerfile'
+
+  release:
+    types: [created, edited, published]
+
+env:
+  IMAGE_NAME: geoscienceaustralia/dea-coastlines
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Get tag for this build if it exists
+      if: github.event_name == 'release'
+      run: |
+        echo "RELEASE=${GITHUB_REF/refs\/tags\/}" >> $GITHUB_ENV
+    - name: Build and push tagged Docker image for release
+      uses: whoan/docker-build-with-cache-action@v4
+      if: github.event_name == 'release'
+      with:
+        image_name: ${{ env.IMAGE_NAME }}
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        image_tag: ${{ env.RELEASE }}
+    - name: Get git commit hash for push to main
+      if: github.event_name != 'release'
+      run: |
+        git fetch --all --tags
+        echo "RELEASE=$(git describe --tags)" >> $GITHUB_ENV
+    - name: Build and Push unstable Docker Image for push to main
+      uses: whoan/docker-build-with-cache-action@v4
+      if: github.event_name != 'release'
+      with:
+        image_name: ${{ env.IMAGE_NAME }}
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        image_tag: latest,${{ env.RELEASE }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -36,12 +36,12 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         image_tag: ${{ env.RELEASE }}
-    - name: Get git commit hash for push to main
+    - name: Get git commit hash for push to branch
       if: github.event_name != 'release'
       run: |
         git fetch --all --tags
         echo "RELEASE=$(git describe --tags)" >> $GITHUB_ENV
-    - name: Build and Push unstable Docker Image for push to main
+    - name: Build and Push unstable Docker Image for push to branch
       uses: whoan/docker-build-with-cache-action@v4
       if: github.event_name != 'release'
       with:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,9 +1,9 @@
-name: Push
+name: Build and push image
 
 on:
   push:
     branches:
-      - github_action_test
+      - develop
     paths:
       - 'coastlines/**'
       - '.github/workflows/docker.yml'

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,12 +1,14 @@
 name: Build and push image
 
+# Run action on both a push to the "develop" branch,
+# and when a Github release is created/edited/published
 on:
   push:
     branches:
       - develop
     paths:
       - 'coastlines/**'
-      - '.github/workflows/docker.yml'
+      - '.github/workflows/docker.yaml'
       - 'Dockerfile'
 
   release:
@@ -24,10 +26,13 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Get tag for this build if it exists
+    # If action is triggered by a release, push image to 
+    # Dockerhub using custom image tag extracted from the release
+    - name: Get current version tag from release to use as image tag
       if: github.event_name == 'release'
       run: |
         echo "RELEASE=${GITHUB_REF/refs\/tags\/}" >> $GITHUB_ENV
+
     - name: Build and push tagged Docker image for release
       uses: whoan/docker-build-with-cache-action@v4
       if: github.event_name == 'release'
@@ -36,12 +41,17 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         image_tag: ${{ env.RELEASE }}
-    - name: Get git commit hash for push to branch
+    
+    # If action is trigged by a push (not release), push a 
+    # latest/unstable image to Dockerhub using image tag based 
+    # on the most recent Github tag and commit hash
+    - name: Get git commit hash for push to branch to use as image tag
       if: github.event_name != 'release'
       run: |
         git fetch --all --tags
         echo "RELEASE=$(git describe --tags)" >> $GITHUB_ENV
-    - name: Build and Push unstable Docker Image for push to branch
+
+    - name: Build and push unstable Docker image for push to branch
       uses: whoan/docker-build-with-cache-action@v4
       if: github.event_name != 'release'
       with:


### PR DESCRIPTION
This PR adds a simple Github actions workflow for building the Coastlines Docker image.

Instead of copying the more complex [DE Africa workflow](https://github.com/digitalearthafrica/deafrica-coastlines/blob/main/.github/workflows/built-test-docker.yaml), I copied the approach from the internal docs guide and `dea-conflux` because I liked how simple they were:

- https://docs.dev.dea.ga.gov.au/procedures/containerised_generic_deployment.html#id2
- https://github.com/GeoscienceAustralia/dea-conflux/blob/main/.github/workflows/push.yml

I'm not sure if I've missed anything important by doing this, but the first run seems to successfully run on Github actions: 
https://github.com/GeoscienceAustralia/dea-coastlines/actions/runs/3125343974/jobs/5069615404

And the image itself is visible on Dockerhub:
https://hub.docker.com/layers/geoscienceaustralia/dea-coastlines/0.0.1/images/sha256-18185f55f3445ff1b145370f5c42bec62fc49f2d1ee6269602cf873f22105d0f?context=explore

This is my first time using Github Actions, so would appreciate any feedback! 😃 